### PR TITLE
Using recommended vm memory settings

### DIFF
--- a/templates/rabbitmq.config.j2
+++ b/templates/rabbitmq.config.j2
@@ -5,7 +5,7 @@
       { "{{ rabbitmq_address }}", {{ rabbitmq_port }} }
     ]},
     {cluster_partition_handling, pause_minority},
-    {vm_memory_high_watermark_paging_ratio, 0.75}
+    {vm_memory_high_watermark_paging_ratio, 0.75},
     {vm_memory_high_watermark, 0.66}
   ]}
 ].

--- a/templates/rabbitmq.config.j2
+++ b/templates/rabbitmq.config.j2
@@ -5,6 +5,7 @@
       { "{{ rabbitmq_address }}", {{ rabbitmq_port }} }
     ]},
     {cluster_partition_handling, pause_minority},
-    {vm_memory_high_watermark, 0.8}
+    {vm_memory_high_watermark_paging_ratio, 0.75}
+    {vm_memory_high_watermark, 0.66}
   ]}
 ].


### PR DESCRIPTION
https://www.rabbitmq.com/production-checklist.html
```
The recommended vm_memory_high_watermark range is 0.40 to 0.66
```